### PR TITLE
Use msgpack 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "msgpack5": "^1.5.0"
+    "msgpack5": "^1.6.0"
   },
   "devDependencies": {
     "colors": "^1.0.3",


### PR DESCRIPTION
1.6.0 just fixed the encoding for 5-bit negative integers (https://github.com/mcollina/msgpack5/commit/f31a3d37696cc4b09d3aab10b1213e7d77f2d2f3)
