### PR TITLE
Do not call handler if it is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ Session.prototype._parse_message = function(msg) {
     var id = msg[1];
     var handler = this._pending_requests[id];
     delete this._pending_requests[id];
-    handler(msg[2], msg[3]);
+    handler && handler(msg[2], msg[3]);
   } else if (msg_type === 2) {
     // notification/event
     //   - msg[1]: event name


### PR DESCRIPTION
Hi!

I'm playing around with [neovim-e](https://github.com/coolwanglu/neovim-e) and noticed that this library crashes if i do not supply a handler for a given function.
Example:

``` js
this.session.request('vim_input', [event])
```

Will throw "Uncaught TypeError: handler is not a function" [here](https://github.com/tarruda/node-msgpack5rpc/blob/master/index.js#L96). I'll have to supply a noop callback to get rid of the error.

I'd propose only calling the handler if supplied as seen in this PR. Thoughts?
